### PR TITLE
Fix admin authentication and add node types

### DIFF
--- a/server/src/admin/module.ts
+++ b/server/src/admin/module.ts
@@ -11,6 +11,7 @@ export default async function adminRoutes(
     const pass = req.headers["auth_pass"];
     if (pass !== AUTH_PASS) {
       reply.code(401).send({ error: "Unauthorized" });
+      return;
     }
   });
   fastify.register(settingsRoutes, { prefix: "/settings" });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -73,6 +73,7 @@ fastify.decorate("authenticate", async function (request, reply) {
     await request.jwtVerify();
   } catch (err) {
     reply.status(401).send({ message: "Unauthorized" });
+    return;
   }
 });
 fastify.register(import("@fastify/formbody"));

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "lib": ["ES2022"],
+    "types": ["node"],
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- ensure unauthorized requests stop processing
- add Node type definitions for TypeScript build
- update authentication decorator to exit on failure

## Testing
- `npx tsc -p ./tsconfig.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_683f62966ecc8327a4fb6a60748aca60